### PR TITLE
rebuild-srpms.sh

### DIFF
--- a/rebuild-srpms.sh
+++ b/rebuild-srpms.sh
@@ -1,0 +1,25 @@
+#!/bin/sh -eu
+
+TMPDIR=$(mktemp -d --suffix "-rebuild-srpms")
+trap 'rm -rf "$TMPDIR"' EXIT
+
+rebuild_srpm() {
+  local tmpdir="$1" srpm="$2" arch="$3"
+  local topdir_tmp="$tmpdir/$srpm.$arch"
+  mkdir $topdir_tmp
+
+  echo "Rebuilding $srpm for $arch"
+
+  dist=$(rpm -qp --qf "%{release}\n" "$srpm" | grep -Po "\.fc\d+")
+  echo "%dist is set to: $dist"
+
+  rpmbuild -rs --nodeps --target "$arch" "$srpm" \
+    -D "dist $dist" \
+    -D "_topdir $topdir_tmp" \
+    -D "_srcrpmdir $arch/sources" 
+
+  rm -rf $topdir_tmp
+}
+export -f rebuild_srpm
+
+parallel -j 100% rebuild_srpm "$TMPDIR" ::: *.src.rpm ::: aarch64 armv7hl i686 ppc64 ppc64le s390x x86_64


### PR DESCRIPTION
Effective way of rebuilding srpms located in current directory.

For usual fedora SRPMs, the speed on 8-core Intel(R) Core(TM) i7-4810MQ CPU @ 2.80GHz
with Samsung MZ7LN512HCHP SSD (up to 540 MB/s, 97 KIOPS) is around 5-20 pkgs/s.

Signed-off-by: Igor Gnatenko <ignatenkobrain@fedoraproject.org>